### PR TITLE
Fix for Node@v22 `assert` being renamed to `with`

### DIFF
--- a/bin/hoard.js
+++ b/bin/hoard.js
@@ -4,7 +4,10 @@ process.removeAllListeners('warning')
 process.on('SIGTERM', () => process.exit());
 process.on('SIGINT', () => process.exit());
 
-import pkg from '../package.json' assert { type: 'json' }
+const { default: pkg } = await import(
+  '../package.json',
+  { with: { type: 'json' } },
+)
 
 import { spawnGit } from '../lib/spawn.js'
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-1",
+  "version": "0.0.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hoard-cli",
-      "version": "0.0.0-1",
+      "version": "0.0.0-2",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-2",
+  "version": "0.0.0-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hoard-cli",
-      "version": "0.0.0-2",
+      "version": "0.0.0-3",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-1",
+  "version": "0.0.0-2",
   "description": "A small (zero dependency) Node.js CLI utility to clone & hoard repositories quickly",
   "homepage": "https://github.com/beepboopbangbang/hoard.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/beepboopbangbang/hoard.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/beepboopbangbang/hoard.js.git"
+    "url": "git+https://github.com/beepboopbangbang/hoard.js.git"
   },
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "jojobyte <byte@jojo.io> (https://jojo.io/)",
   "license": "MIT",
   "engines": {
-    "node": "^18.2.0"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-2",
+  "version": "0.0.0-3",
   "description": "A small (zero dependency) Node.js CLI utility to clone & hoard repositories quickly",
   "homepage": "https://github.com/beepboopbangbang/hoard.js",
   "repository": {


### PR DESCRIPTION
According to https://stackoverflow.com/questions/70106880/err-import-assertion-type-missing-for-import-of-json-file & https://github.com/tc39/proposal-import-attributes ...

```js
// this no longer works
import pkg from '../package.json' assert { type: 'json' }

// in Node@v22 change `assert` to `with`
// however vscode defaults are not yet hip to the jive
import pkg from '../package.json' with { type: 'json' };

// so this works without throwing
// type errors for the `with` keyword
const { default: pkg } = await import(
  '../package.json',
  { with: { type: 'json' } },
);
```

