### PR TITLE
Fix help example usage

### DIFF
--- a/bin/hoard.js
+++ b/bin/hoard.js
@@ -55,6 +55,10 @@ let {
 
 APP_BINS = Object.keys(APP_BINS)
 
+if (APP_REPO.startsWith('git+')) {
+  APP_REPO = APP_REPO.substring(4)
+}
+
 let APP_NS = new URL(APP_REPO)
 let APP_PATH = APP_NS.pathname.substring(1).split('.git')[0]
 let [APP_OWNER] = APP_PATH.split('/')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-3",
+  "version": "0.0.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hoard-cli",
-      "version": "0.0.0-3",
+      "version": "0.0.0-4",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoard-cli",
-  "version": "0.0.0-3",
+  "version": "0.0.0-4",
   "description": "A small (zero dependency) Node.js CLI utility to clone & hoard repositories quickly",
   "homepage": "https://github.com/beepboopbangbang/hoard.js",
   "repository": {


### PR DESCRIPTION
With the recent fix for node@v22, package.json was complaining about needing a fix. the fix broke the help message because it was showing `null` for a URL Origin (`hoard null/beepboopbangbang`).

This should get it showing `hoard https://github.com/beepboopbangbang` in the help instead.